### PR TITLE
Added teleport to opposite side of the board.

### DIFF
--- a/src/Components/Landing/ClassicGame/Board/Board.jsx
+++ b/src/Components/Landing/ClassicGame/Board/Board.jsx
@@ -99,6 +99,7 @@ class Board extends Component {
     }
     
     checkCollision(direction, id) {
+        const {x} = this.state.pacman[0];
         switch(direction){
             case 'UP':
                 if (this.state.board[this.state.pacman[id].y - 1][this.state.pacman[id].x] === 1) {
@@ -114,11 +115,33 @@ class Board extends Component {
                 }
                 break
             case 'LEFT':
+                if (x === 0) {
+                    console.log('TELEPORT')
+                    this.setState({
+                        pacman: [{
+                            ...this.state.pacman[0],
+                            x: 26,
+                            y: 14
+                        }]
+                    })
+                    console.log(this.state.pacman)
+                }
                 if (this.state.board[this.state.pacman[id].y][this.state.pacman[id].x - 1] === 1){
+
                     return false
                 }
                 break
             case 'RIGHT':
+                    if (x === 26) {
+                        console.log('TELEPORT')
+                        this.setState({
+                            pacman: [{
+                                ...this.state.pacman[0],
+                                x: 0,
+                                y: 14
+                            }]
+                        })
+                    }
                 if (this.state.board[this.state.pacman[id].y][this.state.pacman[id].x + 1] === 1){
                     return false
                 }


### PR DESCRIPTION
Pacman will now track when it reaches the end of the east or west hallway, and teleport to the opposite side when it reaches the end. This still needs the transform animation removed during the teleport, so that pac will appear on the other side, rather than zipping through the map to the other side.